### PR TITLE
Use java concurrent instrumentation

### DIFF
--- a/apm-agent-plugins/apm-scala-concurrent-plugin/pom.xml
+++ b/apm-agent-plugins/apm-scala-concurrent-plugin/pom.xml
@@ -17,6 +17,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-java-concurrent-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.scalameta</groupId>
             <artifactId>munit_2.13</artifactId>
             <version>0.7.2</version>

--- a/apm-agent-plugins/apm-scala-concurrent-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-scala-concurrent-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -1,2 +1,2 @@
-co.elastic.apm.agent.scala.concurrent.FutureInstrumentation$ConstructorInstrumentation
-co.elastic.apm.agent.scala.concurrent.FutureInstrumentation$RunInstrumentation
+#co.elastic.apm.agent.scala.concurrent.FutureInstrumentation$ConstructorInstrumentation
+#co.elastic.apm.agent.scala.concurrent.FutureInstrumentation$RunInstrumentation


### PR DESCRIPTION
Demonstrate that the tests pass when just relying on the existing `Executor` instrumentation.